### PR TITLE
bug: iterate over the matches to see if any match was found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "env-variable-secrets-scanner-policy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64",
  "encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "env-variable-secrets-scanner-policy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "encoding",
@@ -505,7 +505,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 [[package]]
 name = "rusty_hog_scanner"
 version = "0.1.0"
-source = "git+https://github.com/raulcabello/rusty-hog/#fcc529f901ea043825d88a6caf66a35159844764"
+source = "git+https://github.com/raulcabello/rusty-hog/#981052cc194b25b881acc089e806799d58d97637"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env-variable-secrets-scanner-policy"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["raulcabello <raul.cabello@suse.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ serde_json = "1.0"
 encoding = "0.2.33"
 base64 = "0.13.0"
 #TODO replace once rusty-hog-scanner is available upstream
-rusty_hog_scanner = { git = "https://github.com/raulcabello/rusty-hog/", revision="fcc529f901ea043825d88a6caf66a35159844764" }
+rusty_hog_scanner = { git = "https://github.com/raulcabello/rusty-hog/", revision="981052cc194b25b881acc089e806799d58d97637" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ use kubewarden_policy_sdk::wapc_guest as guest;
 
 use k8s_openapi::api::core::v1::{EnvVar, PodSpec};
 extern crate kubewarden_policy_sdk as kubewarden;
+use encoding::all::ASCII;
+use encoding::{DecoderTrap, Encoding};
 use kubewarden::{protocol_version_guest, request::ValidationRequest, validate_settings};
 use rusty_hog_scanner::{SecretScanner, SecretScannerBuilder};
 use std::string::String;
@@ -168,12 +170,21 @@ fn scan_text(
 
     for (_, new_line) in lines.enumerate() {
         let results = secret_scanner.matches(new_line);
-        for (reason, _) in results {
-            findings.insert(EnvVarFinding {
-                reason: reason.to_string(),
-                key: key.to_string(),
-                container: container.to_string(),
-            });
+        for (reason, matches) in results {
+            let mut strings_found: Vec<String> = Vec::new();
+            for m in matches {
+                let result = ASCII
+                    .decode(&new_line[m.start()..m.end()], DecoderTrap::Ignore)
+                    .unwrap_or_else(|_| "<STRING DECODE ERROR>".parse().unwrap());
+                strings_found.push(result);
+            }
+            if !strings_found.is_empty() {
+                findings.insert(EnvVarFinding {
+                    reason: reason.to_string(),
+                    key: key.to_string(),
+                    container: container.to_string(),
+                });
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ use kubewarden_policy_sdk::wapc_guest as guest;
 
 use k8s_openapi::api::core::v1::{EnvVar, PodSpec};
 extern crate kubewarden_policy_sdk as kubewarden;
-use encoding::all::ASCII;
-use encoding::{DecoderTrap, Encoding};
 use kubewarden::{protocol_version_guest, request::ValidationRequest, validate_settings};
 use rusty_hog_scanner::{SecretScanner, SecretScannerBuilder};
 use std::string::String;
@@ -171,14 +169,7 @@ fn scan_text(
     for (_, new_line) in lines.enumerate() {
         let results = secret_scanner.matches(new_line);
         for (reason, matches) in results {
-            let mut strings_found: Vec<String> = Vec::new();
-            for m in matches {
-                let result = ASCII
-                    .decode(&new_line[m.start()..m.end()], DecoderTrap::Ignore)
-                    .unwrap_or_else(|_| "<STRING DECODE ERROR>".parse().unwrap());
-                strings_found.push(result);
-            }
-            if !strings_found.is_empty() {
+            for _ in matches {
                 findings.insert(EnvVarFinding {
                     reason: reason.to_string(),
                     key: key.to_string(),


### PR DESCRIPTION
## Description

Currently, we are adding every reasons to findings, which leads to a wrong error message where all reasons are displayed.
To fix this in this PR we iterate over the matches to see if any match was found. Just if it was found it will be added to the findings array.

This can be tested with `ghcr.io/raulcabello/policies/env-variable-secrets-scanner:v0.1.0-test5`

Fix https://github.com/kubewarden/env-variable-secrets-scanner-policy/issues/3
