### PR TITLE
use upstream rusty-hog crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 [[package]]
 name = "rusty_hog_scanner"
 version = "0.1.0"
-source = "git+https://github.com/raulcabello/rusty-hog/#981052cc194b25b881acc089e806799d58d97637"
+source = "git+https://github.com/newrelic/rusty-hog/#0a5c56ef546093d78fbc824b80fd82999c9af4c0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 encoding = "0.2.33"
 base64 = "0.13.1"
-#TODO replace once rusty-hog-scanner is available upstream
-rusty_hog_scanner = { git = "https://github.com/raulcabello/rusty-hog/", revision="981052cc194b25b881acc089e806799d58d97637" }
+rusty_hog_scanner = { git = "https://github.com/newrelic/rusty-hog/", revision="0a5c56ef546093d78fbc824b80fd82999c9af4c0" }


### PR DESCRIPTION
Use revision since there is no new tag created. [More info](https://github.com/newrelic/rusty-hog/pull/45#issuecomment-1295490650)