### PR TITLE
Bump v0.1.7 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "env-variable-secrets-scanner-policy"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64 0.21.2",
  "encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env-variable-secrets-scanner-policy"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["raulcabello <raul.cabello@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.6
+version: 0.1.7
 name: env-variable-secrets-scanner
 displayName: Environment Variable Secrets Scanner
-createdAt: 2023-03-21T12:09:38.582789264Z
+createdAt: 2023-07-07T19:14:30.193712924Z
 description: Policy that inspects env vars and rejects a request if a secret was found
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/env-variable-secrets-scanner-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/env-variable-secrets-scanner:v0.1.6
+  image: ghcr.io/kubewarden/policies/env-variable-secrets-scanner:v0.1.7
 keywords:
 - secrets
 - api keys
@@ -23,13 +23,13 @@ keywords:
 - confidential data leak
 links:
 - name: policy
-  url: https://github.com/kubewarden/env-variable-secrets-scanner-policy/releases/download/v0.1.6/policy.wasm
+  url: https://github.com/kubewarden/env-variable-secrets-scanner-policy/releases/download/v0.1.7/policy.wasm
 - name: source
   url: https://github.com/kubewarden/env-variable-secrets-scanner-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/env-variable-secrets-scanner:v0.1.6
+  kwctl pull ghcr.io/kubewarden/policies/env-variable-secrets-scanner:v0.1.7
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.7 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.7

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
