### PR TITLE
Fix e2e tests

### DIFF
--- a/test_data/pod_creation_with_secrets.json
+++ b/test_data/pod_creation_with_secrets.json
@@ -26,7 +26,7 @@
             },
             {
               "name": "email",
-              "value": "cncf-kubewarden-maintainers@lists.cncf.io"
+              "value": "kubewarden@example.com"
             }
           ]
         }

--- a/test_data/pod_creation_with_secrets_init_and_ephemeral_containers.json
+++ b/test_data/pod_creation_with_secrets_init_and_ephemeral_containers.json
@@ -40,7 +40,7 @@
           "env": [
             {
               "name": "email",
-              "value": "cncf-kubewarden-maintainers@lists.cncf.io"
+              "value": "kubewarden@example.com"
             }
           ]
         }


### PR DESCRIPTION
## Description

Regex check for email is defined here: https://github.com/newrelic/rusty-hog/blob/v1.0.11/src/default_rules.json#L72
It's limited to second-level domains ending with `com|de|cn|net|uk|org|info|nl|eu|ru`

Regex does not include `.io` domain, that we use for mailing list.
Changing test data to use email that would be matched by regex.

Follow-up for [Migrate mailing list mentions to CNCF](https://github.com/kubewarden/env-variable-secrets-scanner-policy/pull/131)