### PR TITLE
docs: KW 1.29 new `spec.timeoutEvalSeconds` helps with policy lengthy evaluation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Both have trade-offs:
 > enough.
 >
 > To work around this issue, users can deploy this policy on a dedicated policy
-> server where the execution timeout is increased or even disabled. Check our
+> server where the execution timeout is increased or even disabled. For
+> example, setting the policy `spec.timeoutEvalSeconds` to `10` (since
+> Kubewarden 1.29) or configuring the PolicyServer. Check our
 > [documentation](https://docs.kubewarden.io/reference/policy-evaluation-timeout)
-> on how to change this configuration.
+> for more info.
 
 ## Settings
 


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/env-variable-secrets-scanner-policy/issues/128

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
